### PR TITLE
fix: add trame namespace packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ build-backend = 'setuptools.build_meta'
 
 [tool.setuptools.packages.find]
 where = ["."]
+# Editable installs don't work with the namespace packages if we
+# include "trame" in this list. We must explicitly include "trame.modules"
+# and "trame.widgets" instead.
+include = ["trame.modules", "trame.widgets", "trame_image_tools"]
 
 [tool.setuptools.package-data]
 trame_image_tools = [
@@ -71,7 +75,6 @@ select = ["E", "W", "F"]
 ignore = []
 fixable = ["ALL"]
 unfixable = []
-
 
 [tool.ruff.format]
 quote-style = "double"

--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/modules/__init__.py
+++ b/trame/modules/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/modules/image_tools.py
+++ b/trame/modules/image_tools.py
@@ -1,0 +1,1 @@
+from trame_image_tools.module import *  # noqa: F403

--- a/trame/widgets/__init__.py
+++ b/trame/widgets/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/widgets/image_tools.py
+++ b/trame/widgets/image_tools.py
@@ -1,0 +1,7 @@
+from trame_image_tools.widgets import *  # noqa: F403
+
+
+def initialize(server):
+    from trame_image_tools import module
+
+    server.enable_module(module)


### PR DESCRIPTION
This adds `image_tools` under both `trame.modules` and `trame.widgets`.

Fixes: #1